### PR TITLE
Fix de loop login/backoffice

### DIFF
--- a/techSolutions-v1/.gitignore
+++ b/techSolutions-v1/.gitignore
@@ -4,6 +4,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+.env
 .env.backup
 .env.production
 .phpactor.json

--- a/techSolutions-v1/app/Http/Controllers/LoginController.php
+++ b/techSolutions-v1/app/Http/Controllers/LoginController.php
@@ -44,7 +44,7 @@ class LoginController extends Controller
         $credenciales = $_request->only('email', 'password');
 
         if (Auth::attempt($credenciales)) {
-
+            /*Added is user not active auth*/
             $user = Auth::user();
             if (!$user->activo) {
                 Auth::logout();

--- a/techSolutions-v1/app/Http/Controllers/LoginController.php
+++ b/techSolutions-v1/app/Http/Controllers/LoginController.php
@@ -50,9 +50,6 @@ class LoginController extends Controller
                 Auth::logout();
                 return redirect()->route('usuario.login')->withError(['email' => 'El usuario se encuentra desactivado']);
             }
-
-            $_request->session()->regenerate();
-            return redirect()->route('backoffice.dashboard');
         }
 
         if (!$token = JWTAuth::attempt($credenciales)) {

--- a/techSolutions-v1/app/Http/Controllers/LoginController.php
+++ b/techSolutions-v1/app/Http/Controllers/LoginController.php
@@ -43,7 +43,7 @@ class LoginController extends Controller
 
         $credenciales = $_request->only('email', 'password');
 
-        /* if (Auth::attempt($credenciales)) {
+        if (Auth::attempt($credenciales)) {
 
             $user = Auth::user();
             if (!$user->activo) {
@@ -54,7 +54,6 @@ class LoginController extends Controller
             $_request->session()->regenerate();
             return redirect()->route('backoffice.dashboard');
         }
-        return redirect()->back()->withErrors(['email' => 'El usuario o contraseña son incorrectos.']); */
 
         if (!$token = JWTAuth::attempt($credenciales)) {
             return response()->json(['error' => 'Credenciales invalidas'], 401);

--- a/techSolutions-v1/routes/web.php
+++ b/techSolutions-v1/routes/web.php
@@ -50,6 +50,11 @@ Route::get('/backoffice', function () {
         return redirect()->route('usuario.login')->withErrors(['message' => 'No existe una sesión activa o el token es inválido.']);
     }
 
+    $user = Auth::user();
+    if ($user == NULL) {
+        return redirect()->route('usuario.login')->withErrors(['message' => 'No existe una sesion activa']);
+    }
+
     try {
         $user = JWTAuth::setToken($token)->authenticate();
         return view('backoffice.dashboard', ['user' => $user]);


### PR DESCRIPTION
Hello! Arreglé la autorización para usuarios sin activar y ya redirige a la pantalla del login. Me falta hacer que se muestre el mensaje que el usuario está desactivado y etc, pero ya está operativo el login, sin ese loop de login y backoffice (lo revisé en la pestaña de Network, y se armaba un loop brígido jaja). No me pude quedar tranquila hasta dejarlo ok. Igual si quieres, ANTES de hacer el merge, darle una probada a mi fork para ver si te funciona.